### PR TITLE
Replace Opbeat logging with Sentry logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,11 @@ Controls whether a default logging configuration should be applied to the applic
 
 _Note: This may be useful for debugging, however in production it is recommended to simply log to stdout (as is the default setup of Celery)_
 
-##### `SETUP_OPBEAT_LOGGING`
+##### `SETUP_SENTRY_LOGGING`
 Defaults to `True` if all required environment variables are set, otherwise `False`.
-Controls whether [Opbeat](https://opbeat.com/) logging handlers should be setup application. The following environment variables are required for Opbeat logging to be setup automatically: `OPBEAT_ORGANIZATION_ID`, `OPBEAT_APP_ID`, `OPBEAT_SECRET_TOKEN`. If all conditions are met, the following will be setup:
+Controls whether [Sentry](https://sentry.io/welcome/) logging handlers should be setup. The `SENTRY_DSN` environment variable is required for Sentry logging to be setup automatically. If this condition is met, the following will be setup:
 
-* add an [OpBeat](https://opbeat.com/) file handle for `ERROR` level logs
-* add an [OpBeat](https://opbeat.com/) [task_failure signal](http://docs.celeryproject.org/en/latest/userguide/signals.html#task-failure) handler to log all faild tasks
+* add a [Sentry signal handler](https://docs.sentry.io/clients/python/integrations/celery/) to log all failed tasks
 
 ##### `QUEUE_PREFIX`
 Used to populate the `queue_name_prefix` value of the connections `broker_transport_options`. Defaults to `'dev'`.

--- a/cadasta/workertoolbox/__init__.py
+++ b/cadasta/workertoolbox/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.0.dev1'
+__version__ = '0.5.0'
 __license__ = 'GNU Affero General Public License v3.0'
 __description__ = 'Cadasta Worker Toolbox'
 __author__ = 'Anthony Lukach'

--- a/cadasta/workertoolbox/__init__.py
+++ b/cadasta/workertoolbox/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.0'
+__version__ = '0.5.0.dev1'
 __license__ = 'GNU Affero General Public License v3.0'
 __description__ = 'Cadasta Worker Toolbox'
 __author__ = 'Anthony Lukach'

--- a/cadasta/workertoolbox/conf.py
+++ b/cadasta/workertoolbox/conf.py
@@ -93,7 +93,7 @@ class Config:
 
         if self.set('SETUP_SENTRY_LOGGING', bool(env.get('SENTRY_DSN'))):
             assert env.get('SENTRY_DSN'), (
-                'Required env variables for Sentry logging are not set')
+                'Required env variable for Sentry logging is not set')
             self.setup_sentry_logging()
 
         # Configure Result Backend

--- a/cadasta/workertoolbox/conf.py
+++ b/cadasta/workertoolbox/conf.py
@@ -91,11 +91,9 @@ class Config:
         if self.set('SETUP_FILE_LOGGING', False):
             self.setup_file_logging()
 
-        sentry_env_vars = [env.get('SENTRY_DSN')]
-        if self.set('SETUP_SENTRY_LOGGING', all(sentry_env_vars)):
-            assert all(env.get('SENTRY_DSN')), (
-                'Not all required env variables for Opbeat logging are set'
-            )
+        if self.set('SETUP_SENTRY_LOGGING', bool(env.get('SENTRY_DSN'))):
+            assert env.get('SENTRY_DSN'), (
+                'Required env variables for Sentry logging are not set')
             self.setup_sentry_logging()
 
         # Configure Result Backend

--- a/cadasta/workertoolbox/conf.py
+++ b/cadasta/workertoolbox/conf.py
@@ -5,9 +5,8 @@ import logging
 import logging.config
 
 from kombu import Exchange, Queue
-from opbeat import Client
-from opbeat.contrib.celery import register_signal
-from opbeat.handlers.logging import OpbeatHandler
+from raven import Client
+from raven.contrib.celery import register_signal, register_logger_signal
 
 # Ensure signals are imported before app starts
 from .signals import *  # NOQA
@@ -92,15 +91,12 @@ class Config:
         if self.set('SETUP_FILE_LOGGING', False):
             self.setup_file_logging()
 
-        opbeat_env_vars = [
-            env.get('OPBEAT_ORGANIZATION_ID'), env.get('OPBEAT_APP_ID'),
-            env.get('OPBEAT_SECRET_TOKEN'),
-        ]
-        if self.set('SETUP_OPBEAT_LOGGING', all(opbeat_env_vars)):
-            assert all(opbeat_env_vars), (
+        sentry_env_vars = [env.get('SENTRY_DSN')]
+        if self.set('SETUP_SENTRY_LOGGING', all(sentry_env_vars)):
+            assert all(env.get('SENTRY_DSN')), (
                 'Not all required env variables for Opbeat logging are set'
             )
-            self.setup_opbeat_logging()
+            self.setup_sentry_logging()
 
         # Configure Result Backend
         self.set('RESULT_DB_USER', 'worker')
@@ -185,28 +181,10 @@ class Config:
         self.set('worker_hijack_root_logger', False)
         logging.config.dictConfig(config)
 
-    def setup_opbeat_logging(self, opbeat_client=None):
-        self._opbeat_client = opbeat_client or Client()
-        self.setup_opbeat_log_handler(self._opbeat_client)
-        self.setup_opbeat_task_signal(self._opbeat_client)
-
-    @staticmethod
-    def setup_opbeat_log_handler(client, logger='', level=logging.ERROR):
-        """
-        Add OpBeat as log handler. Defaults to attaching to root logger
-        and handling logs of level ERROR and above.
-        """
-        logger = logging.getLogger(logger)
-        handler = OpbeatHandler(client)
-        handler.setLevel(level)
-        logger.addHandler(handler)
-
-    @staticmethod
-    def setup_opbeat_task_signal(client):
-        """
-        Setup OpBeat to handle Celery task failures.
-        """
-        register_signal(client)
+    def setup_sentry_logging(self, sentry_client=None, level=logging.ERROR):
+        self._sentry_client = sentry_client or Client(env['SENTRY_DSN'])
+        register_logger_signal(self._sentry_client, loglevel=level)
+        register_signal(self._sentry_client)
 
     @property
     def _default_exchange_obj(self):

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ REQUIREMENTS = [
     'psycopg2>=2.7.1',
     'SQLAlchemy>=1.2,<1.3',
     'mock>=2.0.0',
-    'opbeat>=3.5.2',
     'pycurl>=7.43.0,<=7.44',
+    'raven>=6.6.0'
 ]
 ###
 


### PR DESCRIPTION
Opbeat is closing down, so we need another way to track errors besides log files. Sentry provides a similar service. 

## Notable changes

- Replace Opbeat setup with the equivalent Sentry setup. 
- Simplified the code a bit, mainly because Sentry's Celery logging is set up slightly differently. I merged the equivalent functionality from `setup_opbeat_log_handler` and `setup_opbeat_task_signal` into  `setup_sentry_logging` and adapted the tests accordingly. I not 100% sure that what I've done is right, I don't know the full back-story about splitting the setup procedure into three methods, so please do push back if you have concerns. 