### PR TITLE
Support setting Sentry arguments via env vars

### DIFF
--- a/cadasta/workertoolbox/__init__.py
+++ b/cadasta/workertoolbox/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 __license__ = 'GNU Affero General Public License v3.0'
 __description__ = 'Cadasta Worker Toolbox'
 __author__ = 'Anthony Lukach'

--- a/cadasta/workertoolbox/conf.py
+++ b/cadasta/workertoolbox/conf.py
@@ -180,7 +180,15 @@ class Config:
         logging.config.dictConfig(config)
 
     def setup_sentry_logging(self, sentry_client=None, level=logging.ERROR):
-        self._sentry_client = sentry_client or Client(env['SENTRY_DSN'])
+        self._sentry_client = (
+            sentry_client or
+            Client(**{k: v for k, v in {
+                'dsn': env['SENTRY_DSN'],
+                'name': env.get('SENTRY_NAME'),
+                'environment': env.get('SENTRY_ENVIRONMENT'),
+                'release': env.get('SENTRY_RELEASE'),
+            }.items() if v})
+        )
         register_logger_signal(self._sentry_client, loglevel=level)
         register_signal(self._sentry_client)
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2,8 +2,6 @@ import logging
 import unittest
 from mock import patch
 
-from raven import Client
-
 from cadasta.workertoolbox.conf import Config
 
 
@@ -139,14 +137,24 @@ class TestConfigClass(unittest.TestCase):
         Config(SETUP_FILE_LOGGING=False).setup_file_logging(my_logging_config)
         logging.config.dictConfig.assert_called_once_with(my_logging_config)
 
-    @patch('cadasta.workertoolbox.conf.env', {'SENTRY_DSN': 'https://example.com'})
+    @patch('cadasta.workertoolbox.conf.env', {
+        'SENTRY_DSN': 'https://example.com',
+        'SENTRY_NAME': 'foo',
+        'SENTRY_ENVIRONMENT': 'bar',
+        'SENTRY_RELEASE': '987',
+    })
     @patch('cadasta.workertoolbox.conf.Client')
     @patch('cadasta.workertoolbox.conf.register_logger_signal')
     @patch('cadasta.workertoolbox.conf.register_signal')
     def test_setup_sentry_tools(self, register_signal, logger_signal, Client):
         """ Ensure sentry logging is called if env variable is set """
         Config()
-        Client.assert_called_once_with('https://example.com')
+        Client.assert_called_once_with(
+            dsn='https://example.com',
+            name='foo',
+            environment='bar',
+            release='987',
+        )
         logger_signal.assert_called_once_with(Client.return_value, loglevel=logging.ERROR)
         register_signal.assert_called_once_with(Client.return_value)
 


### PR DESCRIPTION
In #7 we forgot to support allowing Sentry details such as 'environment' and 'release' to be specified via environment variables.

I believe this should be added.